### PR TITLE
test(client): add initial test suite for Client class

### DIFF
--- a/rlapi/client.py
+++ b/rlapi/client.py
@@ -129,6 +129,7 @@ class Client:
         """
         await self._session.close()
 
+
     def destroy(self) -> None:
         """
         Detach underlying session.
@@ -217,7 +218,7 @@ class Client:
         for tries in range(5):
             async with self._session.get(url, headers=headers, params=params) as resp:
                 data = await json_or_text(resp)
-                search_query_limit = int(resp.headers.get("X-Search-Query-Limit", 0))
+                search_query_limit = int(resp.headers.get("X-Search-Query-Limit", "0"))
                 if search_query_limit > 0:  # avoid infinite loops due to limit == 0
                     self.SEARCH_QUERY_LIMIT = search_query_limit
                 if resp.status == 200:

--- a/tests/fixtures/player_not_found.json
+++ b/tests/fixtures/player_not_found.json
@@ -1,0 +1,4 @@
+{
+  "error": "Player not found",
+  "code": 404
+}

--- a/tests/fixtures/player_profile.json
+++ b/tests/fixtures/player_profile.json
@@ -1,0 +1,34 @@
+{
+  "platform": "Steam",
+  "platformId": "76561198012345678",
+  "platformSlug": "steam",
+  "player_name": "TestPlayer",
+  "avatar": "https://example.com/avatar.jpg",
+  "rank": {
+    "playlist": "Ranked Doubles",
+    "tier": "Grand Champion",
+    "division": "Division IV",
+    "rating": 1800
+  },
+  "stats": {
+    "goals": 1000,
+    "assists": 500,
+    "saves": 300,
+    "shots": 1200,
+    "mvps": 100
+  },
+  "player_skills": [
+    {
+      "playlist": 11,
+      "tier": 21,
+      "division": 3,
+      "mu": 25.0,
+      "skill": 1800,
+      "sigma": 8.333,
+      "win_streak": 5,
+      "matches_played": 100,
+      "lifetime_matches_played": 5000,
+      "placement_matches_played": 10
+    }
+  ]
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,46 @@
+import pytest
+import json
+from aiohttp import web
+from rlapi.client import Client
+from rlapi.enums import Platform, PlaylistKey
+from rlapi.errors import PlayerNotFound
+from unittest.mock import patch, AsyncMock
+
+
+@pytest.mark.asyncio
+async def test_client_initialization():
+    """Test that the Client initializes correctly."""
+    with patch('rlapi.client.Client._get_access_token', new_callable=AsyncMock) as mock_get_token:
+        mock_get_token.return_value = "fake_token"
+        client = Client(client_id="test_client_id", client_secret="test_client_secret")
+        assert client._client_id == "test_client_id"
+        assert client._client_secret == "test_client_secret"
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_player_by_id_success():
+    """Test successful player lookup by ID."""
+    with patch('rlapi.client.Client._get_access_token', new_callable=AsyncMock) as mock_get_token, \
+         patch('rlapi.client.Client._request', new_callable=AsyncMock) as mock_request:
+        mock_get_token.return_value = "fake_token"
+        mock_request.return_value = [json.load(open("tests/fixtures/player_profile.json"))]
+        client = Client(client_id="test_client_id", client_secret="test_client_secret")
+        player = await client.get_player_by_id(Platform.steam, "76561198012345678")
+        assert player.user_name == "TestPlayer"
+        assert player.platform == Platform.steam
+        assert player.playlists[PlaylistKey.doubles].tier == 21 # Grand Champion is tier 21
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_player_by_id_not_found():
+    """Test player not found by ID."""
+    with patch('rlapi.client.Client._get_access_token', new_callable=AsyncMock) as mock_get_token, \
+         patch('rlapi.client.Client._request', new_callable=AsyncMock) as mock_request:
+        mock_get_token.return_value = "fake_token"
+        mock_request.return_value = [] # Empty list for not found
+        client = Client(client_id="test_client_id", client_secret="test_client_secret")
+        with pytest.raises(PlayerNotFound):
+            await client.get_player_by_id(Platform.steam, "non_existent_id")
+        await client.close()


### PR DESCRIPTION
This pull request introduces the initial test suite for the `rlapi` library, focusing on the core `Client` class.

It addresses issue #5, "Cover code with tests," by providing tests for:
- Client initialization
- Successful player profile lookups
- Player not found scenarios

The tests utilize `unittest.mock.patch` to isolate network requests, ensuring reliable and repeatable testing without requiring live API access.